### PR TITLE
Add admin controller for OOS product notifications

### DIFF
--- a/controllers/admin/AdminOosProductNotificationsController.php
+++ b/controllers/admin/AdminOosProductNotificationsController.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ * 2017 - thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @author      thirty bees <info@thirtybees.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ * U.S.A. Trademark of thirty bees
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+class AdminOosProductNotificationsController extends ModuleAdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    public function initContent()
+    {
+        if (Tools::isSubmit('delete' . $this->module->name)) {
+            $subscriberId = (int)Tools::getValue('id_mailalert_customer_oos');
+            $productId = (int)Tools::getValue('id_product');
+
+            if ($subscriberId) {
+                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
+                $this->confirmations[] = $this->module->l('The notification has been successfully deleted.');
+                Tools::redirectAdmin($this->context->link->getAdminLink('AdminOosProductNotifications', true, ['id_product' => $productId]));
+            }
+        }
+
+        parent::initContent();
+
+        if ($this->module->customer_qty) {
+            $this->content .= $this->module->renderList();
+        }
+
+        $this->context->smarty->assign([
+            'content' => $this->content,
+        ]);
+    }
+}

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+
+header("Location: ../");
+exit;

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -172,6 +172,10 @@ class MailAlerts extends Module
             }
         }
 
+        if (! $this->uninstallTab()) {
+            return false;
+        }
+
         return parent::uninstall();
     }
 
@@ -196,7 +200,8 @@ class MailAlerts extends Module
             !$this->registerHook('actionProductCoverage') ||
             !$this->registerHook('actionOrderReturn') ||
             !$this->registerHook('actionOrderEdited') ||
-            !$this->registerHook('displayHeader')
+            !$this->registerHook('displayHeader') ||
+            !$this->installTab()
         ) {
             return false;
         }
@@ -230,30 +235,8 @@ class MailAlerts extends Module
      */
     public function getContent()
     {
-        if (Tools::isSubmit('delete' . $this->name)) {
-            $subscriberId = (int)Tools::getValue('id_mailalert_customer_oos');
-            $productId = (int)Tools::getValue('id_product');
-
-            if ($subscriberId) {
-                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
-                $this->context->controller->confirmations[] = $this->l('The notification has been successfully deleted.');
-
-                Tools::redirectAdmin(Context::getContext()->link->getAdminLink('AdminModules', true, [
-                    'configure' => 'mailalerts',
-                    'module_name' => 'mailalerts',
-                    'id_product' => $productId,
-                ]) . '#subscribers');
-            }
-        }
-
         $html = $this->postProcess();
         $html .= $this->renderForm();
-
-        if ($this->customer_qty) {
-            $html .= "<a id='subscribers'></a>";
-            $html .= $this->renderList();
-        }
-
         return $html;
     }
 
@@ -542,7 +525,7 @@ class MailAlerts extends Module
      * @throws PrestaShopException
      * @throws SmartyException
      */
-    protected function renderList()
+    public function renderList()
     {
         $productId = (int)Tools::getValue('id_product');
 
@@ -587,14 +570,11 @@ class MailAlerts extends Module
             $helper->actions = ['delete'];
             $helper->no_link = true;
             $helper->show_toolbar = false;
-            $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-                'configure' => 'mailalerts',
-                'module_name' => 'mailalerts',
-            ]);
-            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),  ['<a href="'.$url.'#subscribers">']);
+            $url = Context::getContext()->link->getAdminLink('AdminOosProductNotifications');
+            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),  ['<a href="'.$url.'">']);
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite('AdminOosProductNotifications');
+            $helper->currentIndex = Context::getContext()->link->getAdminLink('AdminOosProductNotifications', false);
             $content = $this->getProductListSubscribers($productId);
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -637,8 +617,8 @@ class MailAlerts extends Module
             $helper->show_toolbar = false;
             $helper->title = $this->l('Products with notifications');
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite('AdminOosProductNotifications');
+            $helper->currentIndex = Context::getContext()->link->getAdminLink('AdminOosProductNotifications', false);
             $content = $this->getProductsSubscribers();
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -653,7 +633,7 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    protected function getProductsSubscribers()
+    public function getProductsSubscribers()
     {
         $langId = (int)Context::getContext()->language->id;
         $conn = Db::getInstance();
@@ -688,7 +668,7 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    protected function getProductListSubscribers($productId)
+    public function getProductListSubscribers($productId)
     {
         $langId = (int)Context::getContext()->language->id;
         $conn = Db::getInstance();
@@ -1426,6 +1406,48 @@ class MailAlerts extends Module
     }
 
     /**
+     * Install admin tab
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected function installTab()
+    {
+        $tabId = (int) Tab::getIdFromClassName('AdminOosProductNotifications');
+        if ($tabId) {
+            return true;
+        }
+
+        $tab = new Tab();
+        $tab->active = 1;
+        $tab->class_name = 'AdminOosProductNotifications';
+        $tab->module = $this->name;
+        $tab->id_parent = (int) Tab::getIdFromClassName('AdminCatalog');
+        foreach (Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = $this->l('OOS Product Notifications');
+        }
+
+        return (bool) $tab->add();
+    }
+
+    /**
+     * Uninstall admin tab
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected function uninstallTab()
+    {
+        $tabId = (int) Tab::getIdFromClassName('AdminOosProductNotifications');
+        if ($tabId) {
+            $tab = new Tab($tabId);
+            return $tab->delete();
+        }
+
+        return true;
+    }
+
+    /**
      * Created databases tables
      *
      * @return bool
@@ -1538,12 +1560,10 @@ class MailAlerts extends Module
     public function renderCnt($value, $row)
     {
         $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-            'configure' => 'mailalerts',
-            'module_name' => 'mailalerts',
+        $url = Context::getContext()->link->getAdminLink('AdminOosProductNotifications', true, [
             'id_product' => $productId,
         ]);
-        return '<a href="'.$url.'#subscribers">'.Tools::safeOutput($value).'</a>';
+        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
     }
 
 
@@ -1589,26 +1609,4 @@ class MailAlerts extends Module
         return (int)Configuration::get('PS_LANG_DEFAULT');
     }
 
-    /**
-     * @param string $value
-     * @param array $row
-     *
-     * @return string
-     *
-     * @throws PrestaShopException
-     */
-    public function renderDeleteButton($value, $row)
-    {
-        $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-            'configure' => 'mailalerts',
-            'delete_mailalert' => 1,
-            'id_product' => $productId,
-        ]);
-
-        return '<a href="'.$url.'" style="color: red; text-decoration: underline;"
-                    onclick="return confirm(\''.$this->l('Are you sure you want to delete this notification?').'\')">
-                    '.$this->l('Delete').'
-                </a>';
-    }
 }


### PR DESCRIPTION
## Summary
- move subscriber list to new admin controller
- add Catalog menu entry "OOS Product Notifications"
- update list rendering and links to use new controller

## Testing
- `php -l mailalerts.php`
- `php -l controllers/admin/AdminOosProductNotificationsController.php`
- `php -l controllers/admin/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8099b98832d83e4bcf4779c2e79