### PR TITLE
Move OOS alerts to dedicated admin controller

### DIFF
--- a/controllers/admin/AdminMailAlertOosController.php
+++ b/controllers/admin/AdminMailAlertOosController.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ * 2017 - thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @author      thirty bees <info@thirtybees.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ * U.S.A. Trademark of thirty bees
+ */
+
+class AdminMailAlertOosController extends ModuleAdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    public function initContent()
+    {
+        if (Tools::isSubmit('deletemailalerts')) {
+            $subscriberId = (int) Tools::getValue('id_mailalert_customer_oos');
+            $productId = (int) Tools::getValue('id_product');
+
+            if ($subscriberId) {
+                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
+                $this->confirmations[] = $this->module->l('The notification has been successfully deleted.');
+
+                $link = Context::getContext()->link->getAdminLink('AdminMailAlertOos');
+                if ($productId) {
+                    $link .= '&id_product=' . $productId;
+                }
+                Tools::redirectAdmin($link);
+            }
+        }
+
+        if ($this->module->customer_qty) {
+            $this->content .= $this->module->renderList();
+        }
+
+        parent::initContent();
+    }
+}

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+
+header("Location: ../");
+exit;

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -172,7 +172,11 @@ class MailAlerts extends Module
             }
         }
 
-        return parent::uninstall();
+        if (!parent::uninstall()) {
+            return false;
+        }
+
+        return $this->uninstallTab();
     }
 
     /**
@@ -217,6 +221,35 @@ class MailAlerts extends Module
             }
         }
 
+        if (! $this->installTab()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function installTab()
+    {
+        $tab = new Tab();
+        $tab->class_name = 'AdminMailAlertOos';
+        $tab->module = $this->name;
+        $tab->id_parent = (int) Tab::getIdFromClassName('AdminCatalog');
+        $tab->active = 1;
+        foreach (Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = $this->l('OOS Product Notifications');
+        }
+
+        return (bool) $tab->add();
+    }
+
+    protected function uninstallTab()
+    {
+        $idTab = (int) Tab::getIdFromClassName('AdminMailAlertOos');
+        if ($idTab) {
+            $tab = new Tab($idTab);
+            return (bool) $tab->delete();
+        }
+
         return true;
     }
 
@@ -230,29 +263,8 @@ class MailAlerts extends Module
      */
     public function getContent()
     {
-        if (Tools::isSubmit('delete' . $this->name)) {
-            $subscriberId = (int)Tools::getValue('id_mailalert_customer_oos');
-            $productId = (int)Tools::getValue('id_product');
-
-            if ($subscriberId) {
-                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
-                $this->context->controller->confirmations[] = $this->l('The notification has been successfully deleted.');
-
-                Tools::redirectAdmin(Context::getContext()->link->getAdminLink('AdminModules', true, [
-                    'configure' => 'mailalerts',
-                    'module_name' => 'mailalerts',
-                    'id_product' => $productId,
-                ]) . '#subscribers');
-            }
-        }
-
         $html = $this->postProcess();
         $html .= $this->renderForm();
-
-        if ($this->customer_qty) {
-            $html .= "<a id='subscribers'></a>";
-            $html .= $this->renderList();
-        }
 
         return $html;
     }
@@ -587,14 +599,11 @@ class MailAlerts extends Module
             $helper->actions = ['delete'];
             $helper->no_link = true;
             $helper->show_toolbar = false;
-            $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-                'configure' => 'mailalerts',
-                'module_name' => 'mailalerts',
-            ]);
-            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),  ['<a href="'.$url.'#subscribers">']);
+            $url = Context::getContext()->link->getAdminLink('AdminMailAlertOos');
+            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName), ['<a href="'.$url.'">']);
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
+            $helper->currentIndex = AdminController::$currentIndex;
             $content = $this->getProductListSubscribers($productId);
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -637,8 +646,8 @@ class MailAlerts extends Module
             $helper->show_toolbar = false;
             $helper->title = $this->l('Products with notifications');
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
+            $helper->currentIndex = AdminController::$currentIndex;
             $content = $this->getProductsSubscribers();
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);


### PR DESCRIPTION
## Summary
- add admin controller to manage out-of-stock notification records
- install Catalog > OOS Product Notifications tab and remove list from module settings

## Testing
- `php -l mailalerts.php`
- `php -l controllers/admin/AdminMailAlertOosController.php`
- `php -l controllers/admin/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8099b98832d83e4bcf4779c2e79