### PR TITLE
Add admin controller for OOS alerts list

### DIFF
--- a/controllers/admin/AdminMailAlertOosController.php
+++ b/controllers/admin/AdminMailAlertOosController.php
@@ -45,7 +45,7 @@ class AdminMailAlertOosController extends ModuleAdminController
 
             if ($subscriberId) {
                 Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
-                $this->confirmations[] = $this->module->l('The notification has been successfully deleted.');
+                $this->confirmations[] = $this->module->l('The notification has been successfully deleted.', 'adminmailalertooscontroller');
 
                 Tools::redirectAdmin($this->context->link->getAdminLink('AdminMailAlertOos', true, [
                     'id_product' => $productId,
@@ -58,6 +58,193 @@ class AdminMailAlertOosController extends ModuleAdminController
 
     public function renderList()
     {
-        return $this->module->renderList();
+        $productId = (int) Tools::getValue('id_product');
+
+        if ($productId) {
+            $product = new Product($productId, false, $this->context->language->id);
+            $productName = Validate::isLoadedObject($product)
+                ? $product->name
+                : $this->module->l('Deleted product', 'adminmailalertooscontroller');
+
+            $listFields = [
+                'combination_name' => [
+                    'title' => $this->module->l('Combination', 'adminmailalertooscontroller'),
+                    'type'  => 'text',
+                ],
+                'customer_name' => [
+                    'title' => $this->module->l('Customer', 'adminmailalertooscontroller'),
+                    'type'  => 'text',
+                    'callback' => 'renderCustomer',
+                ],
+                'customer_email' => [
+                    'title' => $this->module->l('Email', 'adminmailalertooscontroller'),
+                    'type'  => 'text',
+                ],
+                'date_add' => [
+                    'title' => $this->module->l('Date', 'adminmailalertooscontroller'),
+                    'type'  => 'text',
+                ],
+            ];
+
+            if (!$product->hasAttributes()) {
+                unset($listFields['combination_name']);
+            }
+
+            $helper = new HelperList();
+            $helper->shopLinkType = '';
+            $helper->simple_header = true;
+            $helper->identifier = 'id_mailalert_customer_oos';
+            $helper->actions = ['delete'];
+            $helper->no_link = true;
+            $helper->show_toolbar = false;
+            $url = $this->context->link->getAdminLink('AdminMailAlertOos');
+            $helper->title = Translate::ppTags(
+                sprintf(
+                    $this->module->l('Notification for "%s". [1]Show all[/1]', 'adminmailalertooscontroller'),
+                    $productName,
+                    $productId
+                ),
+                ['<a href="' . $url . '">']
+            );
+            $helper->table = $this->module->name;
+            $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
+            $helper->currentIndex = AdminController::$currentIndex . '&id_product=' . $productId;
+            $content = $this->getProductListSubscribers($productId);
+            $helper->listTotal = count($content);
+
+            return $helper->generateList($content, $listFields);
+        }
+
+        $listFields = [
+            'id_product' => [
+                'title' => $this->module->l('Product ID', 'adminmailalertooscontroller'),
+                'type'  => 'text',
+            ],
+            'reference' => [
+                'title' => $this->module->l('Reference', 'adminmailalertooscontroller'),
+                'type'  => 'text',
+                'callback' => 'renderProduct',
+            ],
+            'product_name' => [
+                'title' => $this->module->l('Product Name', 'adminmailalertooscontroller'),
+                'type'  => 'text',
+                'callback' => 'renderProduct',
+            ],
+            'combination_name' => [
+                'title' => $this->module->l('Combination', 'adminmailalertooscontroller'),
+                'type'  => 'text',
+            ],
+            'cnt' => [
+                'title' => $this->module->l('Number of subscribers', 'adminmailalertooscontroller'),
+                'type'  => 'text',
+                'callback' => 'renderCnt',
+            ],
+        ];
+
+        $helper = new HelperList();
+        $helper->shopLinkType = '';
+        $helper->simple_header = true;
+        $helper->identifier = 'id_product';
+        $helper->actions = [];
+        $helper->no_link = true;
+        $helper->show_toolbar = false;
+        $helper->title = $this->module->l('Products with notifications', 'adminmailalertooscontroller');
+        $helper->table = $this->module->name;
+        $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
+        $helper->currentIndex = AdminController::$currentIndex;
+        $content = $this->getProductsSubscribers();
+        $helper->listTotal = count($content);
+
+        return $helper->generateList($content, $listFields);
+    }
+
+    protected function getProductsSubscribers()
+    {
+        $langId = (int) $this->context->language->id;
+        $conn = Db::getInstance();
+
+        $sql = (new DbQuery())
+            ->select('oos.id_product')
+            ->select('NULLIF(p.reference, "") AS reference')
+            ->select('NULLIF(pl.name, "") AS product_name')
+            ->select('COUNT(DISTINCT oos.id_mailalert_customer_oos) as cnt')
+            ->select('IF(oos.id_product_attribute > 0, GROUP_CONCAT(DISTINCT al.name ORDER BY agl.id_attribute_group SEPARATOR ", "), "") AS combination_name')
+            ->from('mailalert_customer_oos', 'oos')
+            ->leftJoin('product_lang', 'pl', 'pl.id_lang = ' . $langId . ' AND pl.id_product = oos.id_product AND pl.id_shop = oos.id_shop')
+            ->leftJoin('product', 'p', 'p.id_product = oos.id_product')
+            ->leftJoin('product_attribute_combination', 'pac', 'pac.id_product_attribute = oos.id_product_attribute')
+            ->leftJoin('attribute', 'a', 'a.id_attribute = pac.id_attribute')
+            ->leftJoin('attribute_lang', 'al', 'al.id_attribute = a.id_attribute AND al.id_lang = ' . $langId)
+            ->leftJoin('attribute_group_lang', 'agl', 'agl.id_attribute_group = a.id_attribute_group AND agl.id_lang = ' . $langId)
+            ->where('1' . Shop::addSqlRestriction(false, 'oos'))
+            ->groupBy('oos.id_product')
+            ->orderBy('COUNT(DISTINCT oos.id_mailalert_customer_oos) DESC');
+
+        return $conn->executeS($sql);
+    }
+
+    protected function getProductListSubscribers($productId)
+    {
+        $langId = (int) $this->context->language->id;
+        $conn = Db::getInstance();
+
+        $sql = (new DbQuery())
+            ->select('oos.id_mailalert_customer_oos')
+            ->select('oos.id_customer')
+            ->select('IF(oos.id_product_attribute > 0, oos.id_product_attribute, NULL)')
+            ->select('oos.customer_email')
+            ->select('oos.date_add')
+            ->select('COALESCE((
+                            SELECT GROUP_CONCAT(al.`name` ORDER BY agl.`id_attribute_group` SEPARATOR ", ")
+                             FROM `'._DB_PREFIX_.'product_attribute_combination` pac
+                             LEFT JOIN `'._DB_PREFIX_.'attribute` a ON a.`id_attribute` = pac.`id_attribute`
+                             LEFT JOIN `'._DB_PREFIX_.'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group`
+                             LEFT JOIN `'._DB_PREFIX_.'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = '.$this->context->language->id.')
+                             LEFT JOIN `'._DB_PREFIX_.'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = '.$this->context->language->id.')
+                             WHERE pac.id_product_attribute = oos.id_product_attribute
+                             GROUP BY pac.id_product_attribute
+                    ), "-") AS combination_name')
+            ->select('IF(cust.id_customer, CONCAT(cust.firstname, " ", cust.lastname), NULL) AS customer_name')
+            ->from('mailalert_customer_oos', 'oos')
+            ->leftJoin('product_lang', 'pl', 'pl.id_lang = ' . $langId . ' AND pl.id_product = oos.id_product AND pl.id_shop = oos.id_shop')
+            ->leftJoin('customer', 'cust', 'oos.id_customer = cust.id_customer')
+            ->where('oos.id_product = ' . (int) $productId . Shop::addSqlRestriction(false, 'oos'))
+            ->orderBy('oos.id_product')
+            ->orderBy('oos.id_product_attribute')
+            ->orderBy('oos.date_add');
+
+        return $conn->executeS($sql);
+    }
+
+    public function renderCustomer($value, $row)
+    {
+        $customerId = (int) $row['id_customer'];
+        $url = $this->context->link->getAdminLink('AdminCustomers', true, [
+            'id_customer' => $customerId,
+            'viewcustomer' => 1,
+        ]);
+
+        return '<a href="' . $url . '">' . Tools::safeOutput($value) . '</a>';
+    }
+
+    public function renderProduct($value, $row)
+    {
+        $productId = (int) $row['id_product'];
+        $url = $this->context->link->getAdminLink('AdminProducts', true, [
+            'id_product' => $productId,
+            'updateproduct' => 1,
+        ]);
+
+        return '<a href="' . $url . '">' . Tools::safeOutput($value) . '</a>';
+    }
+
+    public function renderCnt($value, $row)
+    {
+        $productId = (int) $row['id_product'];
+        $url = $this->context->link->getAdminLink('AdminMailAlertOos', true, [
+            'id_product' => $productId,
+        ]);
+
+        return '<a href="' . $url . '">' . Tools::safeOutput($value) . '</a>';
     }
 }

--- a/controllers/admin/AdminMailAlertOosController.php
+++ b/controllers/admin/AdminMailAlertOosController.php
@@ -56,9 +56,8 @@ class AdminMailAlertOosController extends ModuleAdminController
         parent::postProcess();
     }
 
-    public function initContent()
+    public function renderList()
     {
-        $this->content = $this->module->renderList();
-        parent::initContent();
+        return $this->module->renderList();
     }
 }

--- a/controllers/admin/AdminMailAlertOosController.php
+++ b/controllers/admin/AdminMailAlertOosController.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+class AdminMailAlertOosController extends ModuleAdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->module = Module::getInstanceByName('mailalerts');
+        parent::__construct();
+    }
+
+    public function postProcess()
+    {
+        if (Tools::isSubmit('delete' . $this->module->name)) {
+            $subscriberId = (int) Tools::getValue('id_mailalert_customer_oos');
+            $productId = (int) Tools::getValue('id_product');
+
+            if ($subscriberId) {
+                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
+                $this->confirmations[] = $this->module->l('The notification has been successfully deleted.');
+
+                Tools::redirectAdmin($this->context->link->getAdminLink('AdminMailAlertOos', true, [
+                    'id_product' => $productId,
+                ]));
+            }
+        }
+
+        parent::postProcess();
+    }
+
+    public function initContent()
+    {
+        $this->content = $this->module->renderList();
+        parent::initContent();
+    }
+}

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+
+header("Location: ../");
+exit;

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -522,189 +522,6 @@ class MailAlerts extends Module
         return $helper->generateForm([$fieldsForm1, $fieldsForm2]);
     }
 
-    /**
-     * @return false|string
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     * @throws SmartyException
-     */
-    public function renderList()
-    {
-        $productId = (int)Tools::getValue('id_product');
-
-        if ($productId) {
-            $product = new Product($productId, false, $this->context->language->id);
-
-            if (Validate::isLoadedObject($product)) {
-                $productName = $product->name;
-            } else {
-                $productName = $this->l('Deleted product');
-            }
-
-            $listFields = [
-                'combination_name' => [
-                    'title' => $this->l('Combination'),
-                    'type' => 'text',
-                ],
-                'customer_name' => [
-                    'title' => $this->l('Customer'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderCustomer'
-                ],
-                'customer_email' => [
-                    'title' => $this->l('Email'),
-                    'type' => 'text',
-                ],
-                'date_add' => [
-                    'title' => $this->l('Date'),
-                    'type' => 'text',
-                ],
-            ];
-
-            if (! $product->hasAttributes()) {
-                unset($listFields['combination_name']);
-            }
-
-            $helper = new HelperList();
-            $helper->shopLinkType = '';
-            $helper->simple_header = true;
-            $helper->identifier = 'id_mailalert_customer_oos';
-            $helper->actions = ['delete'];
-            $helper->no_link = true;
-            $helper->show_toolbar = false;
-            $url = Context::getContext()->link->getAdminLink('AdminMailAlertOos');
-            $helper->title = Translate::ppTags(
-                sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),
-                ['<a href="'.$url.'">']
-            );
-            $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
-            $helper->currentIndex = AdminController::$currentIndex . '&id_product=' . $productId;
-            $content = $this->getProductListSubscribers($productId);
-            $helper->listTotal = count($content);
-            return $helper->generateList($content, $listFields);
-        } else {
-            $listFields = [
-                'id_product' => [
-                    'title' => $this->l('Product ID'),
-                    'type' => 'text',
-                ],
-                'reference' => [
-                    'title' => $this->l('Reference'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderProduct'
-                ],
-                'product_name' => [
-                    'title' => $this->l('Product Name'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderProduct'
-                ],
-                'combination_name' => [
-                    'title' => $this->l('Combination'),
-                    'type' => 'text',
-                ],
-                'cnt' => [
-                    'title' => $this->l('Number of subscribers'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderCnt'
-                ],
-            ];
-
-            $helper = new HelperList();
-            $helper->shopLinkType = '';
-            $helper->simple_header = true;
-            $helper->identifier = 'id_product';
-            $helper->actions = [];
-            $helper->no_link = true;
-            $helper->show_toolbar = false;
-            $helper->title = $this->l('Products with notifications');
-            $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
-            $helper->currentIndex = AdminController::$currentIndex;
-            $content = $this->getProductsSubscribers();
-            $helper->listTotal = count($content);
-            return $helper->generateList($content, $listFields);
-        }
-    }
-
-    /**
-     * Get list content
-     *
-     * @return array
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    public function getProductsSubscribers()
-    {
-        $langId = (int)Context::getContext()->language->id;
-        $conn = Db::getInstance();
-
-        $sql = (new DbQuery())
-            ->select('oos.id_product')
-            ->select('NULLIF(p.reference, "") AS reference')
-            ->select('NULLIF(pl.name, "") AS product_name')
-            ->select('COUNT(DISTINCT oos.id_mailalert_customer_oos) as cnt')
-            ->select('IF(oos.id_product_attribute > 0, GROUP_CONCAT(DISTINCT al.name ORDER BY agl.id_attribute_group SEPARATOR ", "), "") AS combination_name')
-            ->from('mailalert_customer_oos', 'oos')
-            ->leftJoin('product_lang', 'pl', 'pl.id_lang = '.$langId.' AND pl.id_product = oos.id_product AND pl.id_shop = oos.id_shop')
-            ->leftJoin('product', 'p', 'p.id_product = oos.id_product')
-            ->leftJoin('product_attribute_combination', 'pac', 'pac.id_product_attribute = oos.id_product_attribute')
-            ->leftJoin('attribute', 'a', 'a.id_attribute = pac.id_attribute')
-            ->leftJoin('attribute_lang', 'al', 'al.id_attribute = a.id_attribute AND al.id_lang = '.$langId)
-            ->leftJoin('attribute_group_lang', 'agl', 'agl.id_attribute_group = a.id_attribute_group AND agl.id_lang = '.$langId)
-            ->where('1' . Shop::addSqlRestriction(false, 'oos'))
-            ->groupBy('oos.id_product')
-            ->orderBy('COUNT(DISTINCT oos.id_mailalert_customer_oos) DESC');
-
-        return $conn->executeS($sql);
-    }
-
-    /**
-     * Get list content
-     *
-     * @param int $productId
-     *
-     * @return array
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    public function getProductListSubscribers($productId)
-    {
-        $langId = (int)Context::getContext()->language->id;
-        $conn = Db::getInstance();
-        $sql = (new DbQuery())
-            ->select('oos.id_mailalert_customer_oos')
-            ->select('oos.id_customer')
-            ->select('IF(oos.id_product_attribute > 0, oos.id_product_attribute, NULL)')
-            ->select('oos.customer_email')
-            ->select('oos.date_add')
-            ->select('COALESCE((
-                            SELECT GROUP_CONCAT(al.`name` ORDER BY agl.`id_attribute_group` SEPARATOR \', \')
-                             FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.`id_attribute` = pac.`id_attribute`
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group`
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int)Context::getContext()->language->id . ')
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int)Context::getContext()->language->id . ')
-                             WHERE pac.id_product_attribute  = oos.id_product_attribute
-                             GROUP BY pac.id_product_attribute
-                    ), \'-\') AS combination_name')
-            ->select('IF(cust.id_customer, CONCAT(cust.firstname, " ", cust.lastname), NULL) AS customer_name')
-            ->from('mailalert_customer_oos', 'oos')
-            ->leftJoin('product_lang', 'pl', 'pl.id_lang = ' . $langId . ' AND pl.id_product = oos.id_product AND pl.id_shop = oos.id_shop')
-            ->leftJoin('customer', 'cust', 'oos.id_customer = cust.id_customer')
-            ->where('oos.id_product = ' . $productId . Shop::addSqlRestriction(false, 'oos'))
-            ->orderBy('oos.id_product')
-            ->orderBy('oos.id_product_attribute')
-            ->orderBy('oos.date_add');
-        return $conn->executeS($sql);
-    }
 
     /**
      * Configuration field values
@@ -1524,15 +1341,6 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    public function renderCustomer($value, $row)
-    {
-        $customerId = (int)$row['id_customer'];
-        $url = Context::getContext()->link->getAdminLink('AdminCustomers', true, [
-            'id_customer' => $customerId,
-            'viewcustomer' => 1
-        ]);
-        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
-    }
 
     /**
      * @param string $value
@@ -1542,15 +1350,6 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    public function renderProduct($value, $row)
-    {
-        $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminProducts', true, [
-            'id_product' => $productId,
-            'updateproduct' => 1
-        ]);
-        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
-    }
 
     /**
      * @param string $value
@@ -1560,14 +1359,6 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    public function renderCnt($value, $row)
-    {
-        $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminMailAlertOos', true, [
-            'id_product' => $productId,
-        ]);
-        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
-    }
 
 
     /**
@@ -1620,17 +1411,4 @@ class MailAlerts extends Module
      *
      * @throws PrestaShopException
      */
-    public function renderDeleteButton($value, $row)
-    {
-        $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminMailAlertOos', true, [
-            'delete_mailalert' => 1,
-            'id_product' => $productId,
-        ]);
-
-        return '<a href="'.$url.'" style="color: red; text-decoration: underline;"
-                    onclick="return confirm(\''.$this->l('Are you sure you want to delete this notification?').'\')">
-                    '.$this->l('Delete').'
-                </a>';
-    }
 }

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -99,7 +99,7 @@ class MailAlerts extends Module
         $this->author = 'thirty bees';
         $this->need_instance = 0;
 
-        $this->controllers = ['account'];
+        $this->controllers = ['account', 'actions'];
 
         $this->bootstrap = true;
         parent::__construct();

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -172,6 +172,10 @@ class MailAlerts extends Module
             }
         }
 
+        if (! $this->uninstallTab()) {
+            return false;
+        }
+
         return parent::uninstall();
     }
 
@@ -198,6 +202,10 @@ class MailAlerts extends Module
             !$this->registerHook('actionOrderEdited') ||
             !$this->registerHook('displayHeader')
         ) {
+            return false;
+        }
+
+        if (! $this->installTab()) {
             return false;
         }
 
@@ -230,29 +238,8 @@ class MailAlerts extends Module
      */
     public function getContent()
     {
-        if (Tools::isSubmit('delete' . $this->name)) {
-            $subscriberId = (int)Tools::getValue('id_mailalert_customer_oos');
-            $productId = (int)Tools::getValue('id_product');
-
-            if ($subscriberId) {
-                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
-                $this->context->controller->confirmations[] = $this->l('The notification has been successfully deleted.');
-
-                Tools::redirectAdmin(Context::getContext()->link->getAdminLink('AdminModules', true, [
-                    'configure' => 'mailalerts',
-                    'module_name' => 'mailalerts',
-                    'id_product' => $productId,
-                ]) . '#subscribers');
-            }
-        }
-
         $html = $this->postProcess();
         $html .= $this->renderForm();
-
-        if ($this->customer_qty) {
-            $html .= "<a id='subscribers'></a>";
-            $html .= $this->renderList();
-        }
 
         return $html;
     }
@@ -542,7 +529,7 @@ class MailAlerts extends Module
      * @throws PrestaShopException
      * @throws SmartyException
      */
-    protected function renderList()
+    public function renderList()
     {
         $productId = (int)Tools::getValue('id_product');
 
@@ -587,14 +574,14 @@ class MailAlerts extends Module
             $helper->actions = ['delete'];
             $helper->no_link = true;
             $helper->show_toolbar = false;
-            $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-                'configure' => 'mailalerts',
-                'module_name' => 'mailalerts',
-            ]);
-            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),  ['<a href="'.$url.'#subscribers">']);
+            $url = Context::getContext()->link->getAdminLink('AdminMailAlertOos');
+            $helper->title = Translate::ppTags(
+                sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),
+                ['<a href="'.$url.'">']
+            );
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
+            $helper->currentIndex = AdminController::$currentIndex . '&id_product=' . $productId;
             $content = $this->getProductListSubscribers($productId);
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -637,8 +624,8 @@ class MailAlerts extends Module
             $helper->show_toolbar = false;
             $helper->title = $this->l('Products with notifications');
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite('AdminMailAlertOos');
+            $helper->currentIndex = AdminController::$currentIndex;
             $content = $this->getProductsSubscribers();
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -653,7 +640,7 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    protected function getProductsSubscribers()
+    public function getProductsSubscribers()
     {
         $langId = (int)Context::getContext()->language->id;
         $conn = Db::getInstance();
@@ -688,7 +675,7 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    protected function getProductListSubscribers($productId)
+    public function getProductListSubscribers($productId)
     {
         $langId = (int)Context::getContext()->language->id;
         $conn = Db::getInstance();
@@ -1450,6 +1437,44 @@ class MailAlerts extends Module
     }
 
     /**
+     * Install back office tab
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    private function installTab()
+    {
+        $idParent = (int) Tab::getIdFromClassName('AdminCatalog');
+        $tab = new Tab();
+        $tab->active = 1;
+        $tab->class_name = 'AdminMailAlertOos';
+        $tab->id_parent = $idParent;
+        $tab->module = $this->name;
+        foreach (Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = $this->l('OOS Product Notifications');
+        }
+
+        return (bool) $tab->add();
+    }
+
+    /**
+     * Remove back office tab
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    private function uninstallTab()
+    {
+        $idTab = (int) Tab::getIdFromClassName('AdminMailAlertOos');
+        if ($idTab) {
+            $tab = new Tab($idTab);
+            return (bool) $tab->delete();
+        }
+
+        return true;
+    }
+
+    /**
      * Executes sql script
      * @param string $script
      * @param bool $check
@@ -1538,12 +1563,10 @@ class MailAlerts extends Module
     public function renderCnt($value, $row)
     {
         $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-            'configure' => 'mailalerts',
-            'module_name' => 'mailalerts',
+        $url = Context::getContext()->link->getAdminLink('AdminMailAlertOos', true, [
             'id_product' => $productId,
         ]);
-        return '<a href="'.$url.'#subscribers">'.Tools::safeOutput($value).'</a>';
+        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
     }
 
 
@@ -1600,8 +1623,7 @@ class MailAlerts extends Module
     public function renderDeleteButton($value, $row)
     {
         $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-            'configure' => 'mailalerts',
+        $url = Context::getContext()->link->getAdminLink('AdminMailAlertOos', true, [
             'delete_mailalert' => 1,
             'id_product' => $productId,
         ]);


### PR DESCRIPTION
## Summary
- move alert records listing to new AdminMailAlertOos controller
- register "OOS Product Notifications" menu entry under Catalog
- simplify module configuration page

## Testing
- `php -l mailalerts.php`
- `php -l controllers/admin/AdminMailAlertOosController.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8099b98832d83e4bcf4779c2e79