### PR TITLE
Add admin controller for OOS product notifications

### DIFF
--- a/controllers/admin/AdminOosProductNotificationsController.php
+++ b/controllers/admin/AdminOosProductNotificationsController.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ * 2017 - thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @author      thirty bees <info@thirtybees.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ * U.S.A. Trademark of thirty bees
+ */
+
+class AdminOosProductNotificationsController extends ModuleAdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    public function initContent()
+    {
+        if (Tools::isSubmit('delete' . $this->module->name)) {
+            $subscriberId = (int)Tools::getValue('id_mailalert_customer_oos');
+            $productId = (int)Tools::getValue('id_product');
+            if ($subscriberId) {
+                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
+                Tools::redirectAdmin(self::$currentIndex . '&token=' . $this->token . ($productId ? '&id_product=' . $productId : ''));
+            }
+        }
+
+        $this->content .= $this->renderList();
+        parent::initContent();
+    }
+
+    protected function renderList()
+    {
+        $productId = (int)Tools::getValue('id_product');
+
+        if ($productId) {
+            $product = new Product($productId, false, $this->context->language->id);
+            if (Validate::isLoadedObject($product)) {
+                $productName = $product->name;
+            } else {
+                $productName = $this->module->l('Deleted product');
+            }
+
+            $listFields = [
+                'combination_name' => [
+                    'title' => $this->module->l('Combination'),
+                    'type' => 'text',
+                ],
+                'customer_name' => [
+                    'title' => $this->module->l('Customer'),
+                    'type' => 'text',
+                    'callback_object' => $this,
+                    'callback' => 'renderCustomer',
+                ],
+                'customer_email' => [
+                    'title' => $this->module->l('Email'),
+                    'type' => 'text',
+                ],
+                'date_add' => [
+                    'title' => $this->module->l('Date'),
+                    'type' => 'text',
+                ],
+            ];
+
+            if (! $product->hasAttributes()) {
+                unset($listFields['combination_name']);
+            }
+
+            $helper = new HelperList();
+            $helper->shopLinkType = '';
+            $helper->simple_header = true;
+            $helper->identifier = 'id_mailalert_customer_oos';
+            $helper->actions = ['delete'];
+            $helper->no_link = true;
+            $helper->show_toolbar = false;
+            $url = Context::getContext()->link->getAdminLink('AdminOosProductNotifications');
+            $helper->title = Translate::ppTags(sprintf($this->module->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId), ['<a href="' . $url . '">']);
+            $helper->table = $this->module->name;
+            $helper->token = Tools::getAdminTokenLite('AdminOosProductNotifications');
+            $helper->currentIndex = self::$currentIndex . '&id_product=' . $productId;
+            $method = new ReflectionMethod($this->module, 'getProductListSubscribers');
+            $method->setAccessible(true);
+            $content = $method->invoke($this->module, $productId);
+            $helper->listTotal = count($content);
+            return $helper->generateList($content, $listFields);
+        } else {
+            $listFields = [
+                'id_product' => [
+                    'title' => $this->module->l('Product ID'),
+                    'type' => 'text',
+                ],
+                'reference' => [
+                    'title' => $this->module->l('Reference'),
+                    'type' => 'text',
+                    'callback_object' => $this,
+                    'callback' => 'renderProduct',
+                ],
+                'product_name' => [
+                    'title' => $this->module->l('Product Name'),
+                    'type' => 'text',
+                    'callback_object' => $this,
+                    'callback' => 'renderProduct',
+                ],
+                'combination_name' => [
+                    'title' => $this->module->l('Combination'),
+                    'type' => 'text',
+                ],
+                'cnt' => [
+                    'title' => $this->module->l('Number of subscribers'),
+                    'type' => 'text',
+                    'callback_object' => $this,
+                    'callback' => 'renderCnt',
+                ],
+            ];
+
+            $helper = new HelperList();
+            $helper->shopLinkType = '';
+            $helper->simple_header = true;
+            $helper->identifier = 'id_product';
+            $helper->actions = [];
+            $helper->no_link = true;
+            $helper->show_toolbar = false;
+            $helper->title = $this->module->l('Products with notifications');
+            $helper->table = $this->module->name;
+            $helper->token = Tools::getAdminTokenLite('AdminOosProductNotifications');
+            $helper->currentIndex = self::$currentIndex;
+            $method = new ReflectionMethod($this->module, 'getProductsSubscribers');
+            $method->setAccessible(true);
+            $content = $method->invoke($this->module);
+            $helper->listTotal = count($content);
+            return $helper->generateList($content, $listFields);
+        }
+    }
+
+    protected function renderCustomer($value, $row)
+    {
+        $customerId = (int)$row['id_customer'];
+        $url = Context::getContext()->link->getAdminLink('AdminCustomers', true, [
+            'id_customer' => $customerId,
+            'viewcustomer' => 1,
+        ]);
+        return '<a href="' . $url . '">' . Tools::safeOutput($value) . '</a>';
+    }
+
+    protected function renderProduct($value, $row)
+    {
+        $productId = (int)$row['id_product'];
+        $url = Context::getContext()->link->getAdminLink('AdminProducts', true, [
+            'id_product' => $productId,
+            'updateproduct' => 1,
+        ]);
+        return '<a href="' . $url . '">' . Tools::safeOutput($value) . '</a>';
+    }
+
+    protected function renderCnt($value, $row)
+    {
+        $productId = (int)$row['id_product'];
+        $url = Context::getContext()->link->getAdminLink('AdminOosProductNotifications', true, [
+            'id_product' => $productId,
+        ]);
+        return '<a href="' . $url . '">' . Tools::safeOutput($value) . '</a>';
+    }
+
+}
+

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+
+header("Location: ../");
+exit;

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -172,6 +172,10 @@ class MailAlerts extends Module
             }
         }
 
+        if (! $this->uninstallTab()) {
+            return false;
+        }
+
         return parent::uninstall();
     }
 
@@ -217,6 +221,10 @@ class MailAlerts extends Module
             }
         }
 
+        if (! $this->installTab()) {
+            return false;
+        }
+
         return true;
     }
 
@@ -230,29 +238,10 @@ class MailAlerts extends Module
      */
     public function getContent()
     {
-        if (Tools::isSubmit('delete' . $this->name)) {
-            $subscriberId = (int)Tools::getValue('id_mailalert_customer_oos');
-            $productId = (int)Tools::getValue('id_product');
-
-            if ($subscriberId) {
-                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
-                $this->context->controller->confirmations[] = $this->l('The notification has been successfully deleted.');
-
-                Tools::redirectAdmin(Context::getContext()->link->getAdminLink('AdminModules', true, [
-                    'configure' => 'mailalerts',
-                    'module_name' => 'mailalerts',
-                    'id_product' => $productId,
-                ]) . '#subscribers');
-            }
-        }
 
         $html = $this->postProcess();
         $html .= $this->renderForm();
 
-        if ($this->customer_qty) {
-            $html .= "<a id='subscribers'></a>";
-            $html .= $this->renderList();
-        }
 
         return $html;
     }
@@ -1610,5 +1599,28 @@ class MailAlerts extends Module
                     onclick="return confirm(\''.$this->l('Are you sure you want to delete this notification?').'\')">
                     '.$this->l('Delete').'
                 </a>';
+    }
+
+    protected function installTab()
+    {
+        $tab = new Tab();
+        $tab->class_name = 'AdminOosProductNotifications';
+        $tab->module = $this->name;
+        $tab->id_parent = (int)Tab::getIdFromClassName('AdminParentCatalog');
+        $tab->active = 1;
+        foreach (Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = $this->l('OOS Product Notifications');
+        }
+        return $tab->add();
+    }
+
+    protected function uninstallTab()
+    {
+        $idTab = (int)Tab::getIdFromClassName('AdminOosProductNotifications');
+        if ($idTab) {
+            $tab = new Tab($idTab);
+            return $tab->delete();
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated admin controller to manage out-of-stock notification records
- register "OOS Product Notifications" tab under Catalog during install
- remove subscriber list from module settings page

## Testing
- `php -l controllers/admin/AdminOosProductNotificationsController.php`
- `php -l controllers/admin/index.php`
- `php -l mailalerts.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8099b98832d83e4bcf4779c2e79