### PR TITLE
feat: add admin OOS notifications controller

### DIFF
--- a/controllers/admin/AdminOOSProductNotificationsController.php
+++ b/controllers/admin/AdminOOSProductNotificationsController.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ * 2017 - thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ */
+
+class AdminOOSProductNotificationsController extends ModuleAdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    public function initContent()
+    {
+        if (Tools::isSubmit('delete' . $this->module->name)) {
+            $subscriberId = (int) Tools::getValue('id_mailalert_customer_oos');
+            $productId = (int) Tools::getValue('id_product');
+            if ($subscriberId) {
+                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
+                $this->confirmations[] = $this->l('The notification has been successfully deleted.');
+            }
+            Tools::redirectAdmin(self::$currentIndex . '&token=' . $this->token . ($productId ? '&id_product=' . $productId : ''));
+        }
+
+        $this->content .= $this->module->renderList();
+        $this->context->smarty->assign('content', $this->content);
+
+        parent::initContent();
+    }
+}

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+
+header("Location: ../");
+exit;

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -171,6 +171,11 @@ class MailAlerts extends Module
                 return false;
             }
         }
+        $idTab = (int) Tab::getIdFromClassName('AdminOOSProductNotifications');
+        if ($idTab) {
+            $tab = new Tab($idTab);
+            $tab->delete();
+        }
 
         return parent::uninstall();
     }
@@ -215,6 +220,9 @@ class MailAlerts extends Module
             if (! $this->installDb()) {
                 return false;
             }
+        }
+        if (!$this->installTab()) {
+            return false;
         }
 
         return true;
@@ -542,9 +550,10 @@ class MailAlerts extends Module
      * @throws PrestaShopException
      * @throws SmartyException
      */
-    protected function renderList()
+    public function renderList()
     {
         $productId = (int)Tools::getValue('id_product');
+        $isOosController = Tools::getValue('controller') === 'AdminOOSProductNotifications';
 
         if ($productId) {
             $product = new Product($productId, false, $this->context->language->id);
@@ -587,14 +596,22 @@ class MailAlerts extends Module
             $helper->actions = ['delete'];
             $helper->no_link = true;
             $helper->show_toolbar = false;
-            $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-                'configure' => 'mailalerts',
-                'module_name' => 'mailalerts',
-            ]);
-            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),  ['<a href="'.$url.'#subscribers">']);
+            if ($isOosController) {
+                $url = Context::getContext()->link->getAdminLink('AdminOOSProductNotifications');
+            } else {
+                $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
+                    'configure' => 'mailalerts',
+                    'module_name' => 'mailalerts',
+                ]) . '#subscribers';
+            }
+            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName), ['<a href="'.$url.'">']);
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $currentIndex = AdminController::$currentIndex . ($isOosController ? '' : '&configure=' . $this->name);
+            if ($productId) {
+                $currentIndex .= '&id_product=' . $productId;
+            }
+            $helper->currentIndex = $currentIndex;
+            $helper->token = Tools::getAdminTokenLite($isOosController ? 'AdminOOSProductNotifications' : 'AdminModules');
             $content = $this->getProductListSubscribers($productId);
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -637,8 +654,9 @@ class MailAlerts extends Module
             $helper->show_toolbar = false;
             $helper->title = $this->l('Products with notifications');
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $currentIndex = AdminController::$currentIndex . ($isOosController ? '' : '&configure=' . $this->name);
+            $helper->currentIndex = $currentIndex;
+            $helper->token = Tools::getAdminTokenLite($isOosController ? 'AdminOOSProductNotifications' : 'AdminModules');
             $content = $this->getProductsSubscribers();
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -653,7 +671,7 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    protected function getProductsSubscribers()
+    public function getProductsSubscribers()
     {
         $langId = (int)Context::getContext()->language->id;
         $conn = Db::getInstance();
@@ -688,7 +706,7 @@ class MailAlerts extends Module
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    protected function getProductListSubscribers($productId)
+    public function getProductListSubscribers($productId)
     {
         $langId = (int)Context::getContext()->language->id;
         $conn = Db::getInstance();
@@ -1450,6 +1468,29 @@ class MailAlerts extends Module
     }
 
     /**
+     * Create admin tab for notifications management
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected function installTab()
+    {
+        if (Tab::getIdFromClassName('AdminOOSProductNotifications')) {
+            return true;
+        }
+
+        $tab = new Tab();
+        $tab->class_name = 'AdminOOSProductNotifications';
+        $tab->id_parent = (int) Tab::getIdFromClassName('AdminCatalog');
+        $tab->module = $this->name;
+        foreach (Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = $this->l('OOS Product Notifications');
+        }
+
+        return $tab->save();
+    }
+
+    /**
      * Executes sql script
      * @param string $script
      * @param bool $check
@@ -1538,12 +1579,19 @@ class MailAlerts extends Module
     public function renderCnt($value, $row)
     {
         $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-            'configure' => 'mailalerts',
-            'module_name' => 'mailalerts',
-            'id_product' => $productId,
-        ]);
-        return '<a href="'.$url.'#subscribers">'.Tools::safeOutput($value).'</a>';
+        if (Tools::getValue('controller') === 'AdminOOSProductNotifications') {
+            $url = Context::getContext()->link->getAdminLink('AdminOOSProductNotifications', true, [
+                'id_product' => $productId,
+            ]);
+        } else {
+            $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
+                'configure' => 'mailalerts',
+                'module_name' => 'mailalerts',
+                'id_product' => $productId,
+            ]) . '#subscribers';
+        }
+
+        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
     }
 
 


### PR DESCRIPTION
## Summary
- add dedicated `OOS Product Notifications` controller under Catalog for managing out-of-stock alerts
- expose alert list helpers for reuse by new controller
- adjust list rendering links and tokens to support the standalone controller

## Testing
- `php -l mailalerts.php`
- `php -l controllers/admin/AdminOOSProductNotificationsController.php`
- `php -l controllers/admin/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b76e2e3504832db9885b4fde00f0b2