### PR TITLE
Add admin controller for OOS product notifications

### DIFF
--- a/controllers/admin/AdminMailalertsOosController.php
+++ b/controllers/admin/AdminMailalertsOosController.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ * 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * Class AdminMailalertsOosController
+ */
+class AdminMailalertsOosController extends ModuleAdminController
+{
+    /**
+     * AdminMailalertsOosController constructor.
+     */
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    /**
+     * Process actions
+     *
+     * @return void
+     */
+    public function postProcess()
+    {
+        if (Tools::isSubmit('delete'.$this->module->name)) {
+            $subscriberId = (int) Tools::getValue('id_mailalert_customer_oos');
+            $productId = (int) Tools::getValue('id_product');
+            if ($subscriberId) {
+                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = '.$subscriberId);
+                $this->confirmations[] = $this->module->l('The notification has been successfully deleted.', 'AdminMailalertsOosController');
+            }
+            $redirect = $this->context->link->getAdminLink('AdminMailalertsOos');
+            if ($productId) {
+                $redirect .= '&id_product='.$productId;
+            }
+            Tools::redirectAdmin($redirect);
+        }
+        parent::postProcess();
+    }
+
+    /**
+     * Init content
+     *
+     * @return void
+     */
+    public function initContent()
+    {
+        $this->content .= $this->module->renderList('AdminMailalertsOos');
+        parent::initContent();
+    }
+}

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+
+header("Location: ../");
+exit;

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -172,6 +172,8 @@ class MailAlerts extends Module
             }
         }
 
+        $this->uninstallTab();
+
         return parent::uninstall();
     }
 
@@ -217,7 +219,49 @@ class MailAlerts extends Module
             }
         }
 
+        if (! $this->installTab()) {
+            return false;
+        }
+
         return true;
+    }
+
+    /**
+     * Install back office tab
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    protected function installTab()
+    {
+        if (Tab::getIdFromClassName('AdminMailalertsOos')) {
+            return true;
+        }
+
+        $tab = new Tab();
+        $tab->class_name = 'AdminMailalertsOos';
+        $tab->module = $this->name;
+        $tab->id_parent = (int) Tab::getIdFromClassName('AdminCatalog');
+        foreach (Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = $this->l('OOS Product Notifications');
+        }
+
+        return (bool) $tab->add();
+    }
+
+    /**
+     * Remove back office tab
+     *
+     * @return void
+     * @throws PrestaShopException
+     */
+    protected function uninstallTab()
+    {
+        $idTab = (int) Tab::getIdFromClassName('AdminMailalertsOos');
+        if ($idTab) {
+            $tab = new Tab($idTab);
+            $tab->delete();
+        }
     }
 
     /**
@@ -542,7 +586,7 @@ class MailAlerts extends Module
      * @throws PrestaShopException
      * @throws SmartyException
      */
-    protected function renderList()
+    public function renderList($controller = 'AdminModules')
     {
         $productId = (int)Tools::getValue('id_product');
 
@@ -587,14 +631,20 @@ class MailAlerts extends Module
             $helper->actions = ['delete'];
             $helper->no_link = true;
             $helper->show_toolbar = false;
-            $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-                'configure' => 'mailalerts',
-                'module_name' => 'mailalerts',
-            ]);
-            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),  ['<a href="'.$url.'#subscribers">']);
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite($controller);
+            if ($controller === 'AdminModules') {
+                $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+                $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
+                    'configure' => 'mailalerts',
+                    'module_name' => 'mailalerts',
+                ]);
+                $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId), ['<a href="'.$url.'#subscribers">']);
+            } else {
+                $helper->currentIndex = AdminController::$currentIndex;
+                $url = Context::getContext()->link->getAdminLink($controller);
+                $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId), ['<a href="'.$url.'">']);
+            }
             $content = $this->getProductListSubscribers($productId);
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);
@@ -637,8 +687,12 @@ class MailAlerts extends Module
             $helper->show_toolbar = false;
             $helper->title = $this->l('Products with notifications');
             $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->token = Tools::getAdminTokenLite($controller);
+            if ($controller === 'AdminModules') {
+                $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            } else {
+                $helper->currentIndex = AdminController::$currentIndex;
+            }
             $content = $this->getProductsSubscribers();
             $helper->listTotal = count($content);
             return $helper->generateList($content, $listFields);


### PR DESCRIPTION
## Summary
- add `AdminMailalertsOos` controller for back office subscriber management
- register "OOS Product Notifications" tab under Catalog during install
- expose subscription list rendering for both module config and new controller

## Testing
- `php -l controllers/admin/AdminMailalertsOosController.php`
- `php -l mailalerts.php`


------
https://chatgpt.com/codex/tasks/task_e_68b76e2e3504832db9885b4fde00f0b2